### PR TITLE
Add 'direction' state to apollo cache

### DIFF
--- a/backend/graphql.schema.json
+++ b/backend/graphql.schema.json
@@ -413,6 +413,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "direction",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,

--- a/backend/typeDefs.ts
+++ b/backend/typeDefs.ts
@@ -3,6 +3,7 @@ import { gql } from 'apollo-server-express';
 export const typeDefs = gql`
    type Query {
       crossword: Crossword!
+      direction: String!
    }
 
    type Crossword {

--- a/frontend/src/components/VerticalWord/CrosswordBoxContainer.tsx
+++ b/frontend/src/components/VerticalWord/CrosswordBoxContainer.tsx
@@ -14,6 +14,7 @@ const Main = styled.div`
    margin: auto;
    display: flex;
    flex-direction: row;
+   font-size: x-large;
 `;
 const CrosswordContainer = styled.div`
    border-bottom: solid 1px black;

--- a/frontend/src/components/VerticalWord/CrosswordBoxContainer.tsx
+++ b/frontend/src/components/VerticalWord/CrosswordBoxContainer.tsx
@@ -1,10 +1,11 @@
 import React, { FormEvent, useMemo, useState, useEffect, createRef } from 'react';
 import styled from 'styled-components';
-import { Crossword, Point, Answer } from '../../generated/generated';
+import { Crossword, Point, Answer, useDirectionQuery, DirectionDocument } from '../../generated/generated';
 import CrosswordInputBox from './CrosswordInputBox';
 import CrosswordBlankBox from './CrosswordBlankBox';
 import AnswerContainer from '../Answers/AnswerContainer';
 import { getActiveElement } from '@testing-library/user-event/dist/utils';
+import { useApolloClient } from '@apollo/client';
 
 const Main = styled.div`
    width: fit-content;
@@ -72,6 +73,8 @@ export type CrosswordBoxContainerProps = { crossword: Crossword };
 const CrosswordBoxContainer = ({ crossword }: CrosswordBoxContainerProps) => {
    // Initialize empty crossword grid
    const dimension: number = crossword.grid.dimension;
+   const client = useApolloClient();
+   const {data, loading} = useDirectionQuery();
 
    // Initialize the across/down answer maps
    const [downAnswerMap, acrossAnswerMap] = useMemo<Map<number, Answer>[]>(() => {
@@ -137,6 +140,15 @@ const CrosswordBoxContainer = ({ crossword }: CrosswordBoxContainerProps) => {
       let columnIndex = cellNumber % dimension;
       let rowIndex = Math.floor(cellNumber / dimension);
       switch(event.key) {
+
+         // Change whether the user is typing in the across/down direction
+         case 'Shift': {
+            client.writeQuery({
+               query: DirectionDocument,
+               data: { direction: data?.direction === 'across'? 'down' : 'across' }
+            })
+            break;
+         }
          case 'Backspace': 
          case 'Delete': {
             (event.currentTarget as HTMLElement).textContent = '';

--- a/frontend/src/components/VerticalWord/CrosswordBoxContainer.tsx
+++ b/frontend/src/components/VerticalWord/CrosswordBoxContainer.tsx
@@ -210,6 +210,7 @@ const CrosswordBoxContainer = ({ crossword }: CrosswordBoxContainerProps) => {
                               onInput={(event) => crosswordBoxInputHandler(event, cellIndex)}
                               onDelete={(event) => keyStrokeHandler(event, cellIndex)}
                               ref={refGrid[i][j]}
+                              direction={data?.direction}
                            />
                         );
                      }

--- a/frontend/src/components/VerticalWord/CrosswordBoxContainer.tsx
+++ b/frontend/src/components/VerticalWord/CrosswordBoxContainer.tsx
@@ -15,7 +15,6 @@ const Main = styled.div`
    display: flex;
    flex-direction: row;
 `;
-
 const CrosswordContainer = styled.div`
    border-bottom: solid 1px black;
    width: fit-content;
@@ -51,6 +50,30 @@ function checkAnswer(grid: Point[][], downAnswerMap: Map<number, Answer>, across
    }
    return true;
 }
+
+const handleRight = (refGrid: React.RefObject<HTMLDivElement>[][], rowIndex: number, columnIndex: number, dimension: number) => {
+   let current = refGrid[rowIndex][mod(columnIndex+1,dimension)]?.current
+   current?.focus()
+   let count = 1
+   while(current && !(current === getActiveElement(document))) {
+      current = refGrid[rowIndex][mod(columnIndex + count,dimension)]?.current
+      current?.focus()
+      count += 1
+   }
+}
+
+const handleDown = (refGrid: React.RefObject<HTMLDivElement>[][], rowIndex: number, columnIndex: number, dimension: number) => {
+   let current = refGrid[(rowIndex+1)%dimension][columnIndex]?.current
+   current?.focus()
+   let count = 1
+   while(current && !(current === getActiveElement(document))) {
+      current = refGrid[(rowIndex + count)%dimension][columnIndex]?.current
+      current?.focus()
+      count += 1
+   }
+}
+
+
 
 export type CrosswordBoxContainerProps = { crossword: Crossword };
 const CrosswordBoxContainer = ({ crossword }: CrosswordBoxContainerProps) => {
@@ -113,15 +136,18 @@ const CrosswordBoxContainer = ({ crossword }: CrosswordBoxContainerProps) => {
          newGrid[rowIndex][columnIndex].value = input ? input : currentGrid[rowIndex][columnIndex].value;
          return newGrid;
       });
-      if (event.currentTarget.nextSibling) {
-         (event.currentTarget.nextSibling as HTMLElement).focus();
-      }
+
+      console.log(data?.direction)
+      console.log(event.currentTarget)
+      let handle = data?.direction === 'across'? handleRight : handleDown;
+      handle(refGrid, rowIndex, columnIndex, dimension);
    };
 
    // On backspace/delete delete the current element from the grid
    const keyStrokeHandler = (event: React.KeyboardEvent<HTMLDivElement>, cellNumber: number) => {
       let columnIndex = cellNumber % dimension;
       let rowIndex = Math.floor(cellNumber / dimension);
+      console.log(event.key)
       switch(event.key) {
 
          // Change whether the user is typing in the across/down direction
@@ -146,14 +172,7 @@ const CrosswordBoxContainer = ({ crossword }: CrosswordBoxContainerProps) => {
             break
          }
          case 'ArrowRight':{
-            let current = refGrid[rowIndex][mod(columnIndex+1,dimension)]?.current
-            current?.focus()
-            let count = 1
-            while(current && !(current === getActiveElement(document))) {
-               current = refGrid[rowIndex][mod(columnIndex + count,dimension)]?.current
-               current?.focus()
-               count += 1
-            }
+            handleRight(refGrid, rowIndex, columnIndex, dimension)
             break
          }
          case 'ArrowLeft':{

--- a/frontend/src/components/VerticalWord/CrosswordBoxContainer.tsx
+++ b/frontend/src/components/VerticalWord/CrosswordBoxContainer.tsx
@@ -1,5 +1,7 @@
 import React, { FormEvent, useMemo, useState, useEffect, createRef } from 'react';
 import styled from 'styled-components';
+import { mod, deepCopy, createBlankGrid } from '@crossword/utils'
+import { CONFIG } from '@crossword/config';
 import { Crossword, Point, Answer, useDirectionQuery, DirectionDocument } from '../../generated/generated';
 import CrosswordInputBox from './CrosswordInputBox';
 import CrosswordBlankBox from './CrosswordBlankBox';
@@ -23,25 +25,6 @@ const CrosswordRow = styled.div`
    display: flex;
    flex-wrap: wrap;
 `;
-const BLANK_CHARACTER: string = '.'; // determines which cells in the answer should be empty
-
-// Create a new empty Point[][] filled with undefined
-function createBlankGrid(dimension: number): any[][] {
-   return Array(dimension)
-      .fill(undefined)
-      .map(() => Array(dimension).fill(undefined));
-}
-
-// Create a deep copy of any type
-function deepCopy(array: any): any {
-   let copy: any = JSON.parse(JSON.stringify(array));
-   return copy;
-}
-
-// Modulus which works correctly for negative values
-const mod = (n : number, m : number) => {
-   return ((n % m) + m)  % m 
-}
 
 // Compare two grids for equality
 function checkAnswer(grid: Point[][], downAnswerMap: Map<number, Answer>, acrossAnswerMap: Map<number, Answer>): boolean {
@@ -217,7 +200,7 @@ const CrosswordBoxContainer = ({ crossword }: CrosswordBoxContainerProps) => {
                <CrosswordRow key={i}>
                   {row.map((point, j) => {
                      let cellIndex = i * dimension + j;
-                     if (point.value === BLANK_CHARACTER) {
+                     if (point.value === CONFIG.BLANK_CHARACTER) {
                         return <CrosswordBlankBox ref={refGrid[i][j]} key={cellIndex} />;
                      } else {
                         return (

--- a/frontend/src/components/VerticalWord/CrosswordInputBox.tsx
+++ b/frontend/src/components/VerticalWord/CrosswordInputBox.tsx
@@ -2,12 +2,16 @@ import styled from "styled-components";
 import React from "react";
 import { memo, FormEvent } from "react";
 
-const CrosswordBox = styled.div`
 
+
+// Make style of focus a function of the current direction
+export type CrosswordBoxStyleProps = {
+  direction: string;
+}
+const CrosswordBox = styled.div<CrosswordBoxStyleProps>`
   :empty:not(:focus):before{
     content:attr(placeholder);
     color: rgba(0, 0, 0, 0.5);
-    
   }
   text-transform: uppercase;
   background-color: white;
@@ -20,19 +24,34 @@ const CrosswordBox = styled.div`
   justify-content: center;
   align-items: center;
   &:focus {
-    background-color: gray;
+    background-color: transparent;
+    outline: none;
+    box-shadow:
+      inset 0px 0px 0px 1px white, 
+      inset 0px 0px 0px 2px ${props => props.direction === 'down'? 'red' : 'green'};
+  }
+  :focus::after{
+    content: "";
+    position: absolute;
+    width: .8em;
+    height: .8em;
+    background: linear-gradient(to bottom right, ${({ direction }) => direction === 'down'? 'red' : 'green'} 50%, rgba(0,0,0,.5) 50%, transparent 52%);
+    transform: rotate(${({direction}) => direction ==='down'? '-135deg': '135deg'}) translate(-10px, -10px);
+    box-shadow: 0px 0px 0px -2px rgba(0, 0, 0, 0.5);
   }
   caret-color: transparent;
 `;
 
+
 export type CrossWordInputBoxProps = {
+  direction: string | undefined;
   value: string;
   onInput?: (event: FormEvent<HTMLDivElement>) => void;
   onDelete: (event: React.KeyboardEvent<HTMLDivElement>) => void;
 };
-const CrosswordInput = React.forwardRef<HTMLDivElement,CrossWordInputBoxProps>(({ value, onDelete, onInput}, ref) => {
+const CrosswordInput = React.forwardRef<HTMLDivElement,CrossWordInputBoxProps>(({ direction, value, onDelete, onInput}, ref) => {
   return (
-    <CrosswordBox ref={ref} placeholder={Number(value)? value : ""} contentEditable onInput={onInput} onKeyDown={onDelete}></CrosswordBox>
+   <CrosswordBox direction={direction as string} ref={ref} placeholder={Number(value)? value : ""} contentEditable onInput={onInput} onKeyDown={onDelete}/> 
   );
 });
 const CrosswordInputBox = memo(CrosswordInput);

--- a/frontend/src/components/VerticalWord/CrosswordInputBox.tsx
+++ b/frontend/src/components/VerticalWord/CrosswordInputBox.tsx
@@ -46,12 +46,13 @@ const CrosswordBox = styled.div<CrosswordBoxStyleProps>`
 export type CrossWordInputBoxProps = {
   direction: string | undefined;
   value: string;
+  onDoubleClick?:(event: React.MouseEvent) => void;
   onInput?: (event: FormEvent<HTMLDivElement>) => void;
   onDelete: (event: React.KeyboardEvent<HTMLDivElement>) => void;
 };
-const CrosswordInput = React.forwardRef<HTMLDivElement,CrossWordInputBoxProps>(({ direction, value, onDelete, onInput}, ref) => {
+const CrosswordInput = React.forwardRef<HTMLDivElement,CrossWordInputBoxProps>(({ direction, value, onDoubleClick, onDelete, onInput}, ref) => {
   return (
-   <CrosswordBox direction={direction as string} ref={ref} placeholder={Number(value)? value : ""} contentEditable onInput={onInput} onKeyDown={onDelete}/> 
+   <CrosswordBox direction={direction as string} ref={ref} placeholder={Number(value)? value : ""} contentEditable onDoubleClick={onDoubleClick} onInput={onInput} onKeyDown={onDelete}/> 
   );
 });
 const CrosswordInputBox = memo(CrosswordInput);

--- a/frontend/src/components/VerticalWord/CrosswordInputBox.tsx
+++ b/frontend/src/components/VerticalWord/CrosswordInputBox.tsx
@@ -36,7 +36,7 @@ const CrosswordBox = styled.div<CrosswordBoxStyleProps>`
     width: .8em;
     height: .8em;
     background: linear-gradient(to bottom right, ${({ direction }) => direction === 'down'? 'red' : 'green'} 50%, rgba(0,0,0,.5) 50%, transparent 52%);
-    transform: rotate(${({direction}) => direction ==='down'? '-135deg': '135deg'}) translate(-10px, -10px);
+    transform: rotate(${({direction}) => direction ==='down'? '-135deg': '135deg'}) translate(-.65em, -.65em);
     box-shadow: 0px 0px 0px -2px rgba(0, 0, 0, 0.5);
   }
   caret-color: transparent;

--- a/frontend/src/queries/directionQuery.graphql
+++ b/frontend/src/queries/directionQuery.graphql
@@ -1,0 +1,3 @@
+query Direction {
+   direction @client
+}

--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -6,4 +6,5 @@ export const CONFIG = Object.freeze({
    SSL_CERT: NODE_ENV === 'production' ? '/home/opc/certificate.crt' : '',
    SSL_KEY: NODE_ENV === 'production' ? '/home/opc/private.key' : '',
    STAGE: NODE_ENV,
+   BLANK_CHARACTER: '.',
 });

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -1,0 +1,9 @@
+// Modulus which works correctly for negative values
+export const mod = (n, m) => ((n % m) + m) % m;
+
+// Create a deep copy of any type
+export const deepCopy = (input) => JSON.parse(JSON.stringify(input));
+
+// Create a new empty Point[][] filled with undefined
+export const createBlankGrid = (dimension) => Array(dimension).fill(undefined).map(() => Array(dimension).fill(undefined));
+

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "@crossword/utils",
+    "version": "1.0.0",
+    "type": "module",
+    "main": "index.ts"
+}
+  


### PR DESCRIPTION
### Motivation
---

We need some local state to determine the user's current writing direction (down or across)

### Changes
---
Add logic to manage direction state through Apollo cache
Change direction by pressing "Shift"

### Tests
---

locally
![image](https://user-images.githubusercontent.com/7201215/166171107-cf280923-6206-4b78-bd9e-0f14ec7a99d6.png)
![image](https://user-images.githubusercontent.com/7201215/166171085-5877e451-6e50-488c-88e3-61879c491177.png)



### Picture of Cat (Not Optional)
---
![image](https://user-images.githubusercontent.com/7201215/166158416-4153193d-3f19-45f4-a2a3-43bd6b244d7a.png)